### PR TITLE
Feature/ruby19 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "http://rubygems.org <http://rubygems.org/>"
+gemspec

--- a/amp.gemspec
+++ b/amp.gemspec
@@ -1,43 +1,31 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-#require "ruby_speech/version"
+
+#require "amp"
 
 Gem::Specification.new do |s|
   s.name        = "amp"
-  s.developer "Michael Edgar", "adgar@carboni.ca"
-  s.developer "Ari Brown", "seydar@carboni.ca"
-  self.url = "http://amp.carboni.ca/"
-  self.spec_extras = {:extensions => ["ext/amp/mercurial_patch/extconf.rb",
-                                 "ext/amp/priority_queue/extconf.rb",
-                                 "ext/amp/support/extconf.rb",
-                                 "ext/amp/bz2/extconf.rb"]}
-  self.need_rdoc = false
-  self.summary = "Version Control in Ruby. Mercurial Compatible. Big Ideas."
-  extra_dev_deps << ["rtfm", ">= 0.5.1"] << ["yard", ">= 0.4.0"] << ["minitest", ">= 1.5.0"]
+  s.authors     = ["Michael Edgar", "Ari Brown"]
+  s.email       = ["adgar@carboni.ca", "seydar@carboni.ca"]
+  s.version     = '0.5.3' #Amp::VERSION
+  s.homepage = "http://amp.carboni.ca/"
+  s.summary = "Version Control in Ruby. Mercurial Compatible. Big Ideas."
+  s.rubyforge_project = 'amp'
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.require_paths = ["lib"]
+
+  s.add_development_dependency %q<bundler>, ["~> 1.0.0"]
+  s.add_development_dependency %q<rtfm>, ["~> 0.5.1"]
+  s.add_development_dependency %q<yard>, [">= 0.4.0"]
+  s.add_development_dependency %q<minitest>, [">= 1.5.0"]
+
+  # self.spec_extras = {:extensions => ["ext/amp/mercurial_patch/extconf.rb",
+  #                                "ext/amp/priority_queue/extconf.rb",
+  #                                "ext/amp/support/extconf.rb",
+  #                                "ext/amp/bz2/extconf.rb"]}
+  # self.need_rdoc = false
+
 end
-
-# #  s.version     = RubySpeech::VERSION
-#   s.authors     = ["Ben Langfeld"]
-#   s.email       = ["ben@langfeld.me"]
-#   s.homepage    = "https://github.com/benlangfeld/ruby_speech"
-#   s.summary     = %q{A ruby library for TTS & ASR document preparation}
-#   s.description = %q{Prepare SSML and GRXML documents with ease}
-
-#   s.rubyforge_project = "ruby_speech"
-
-#   s.files         = `git ls-files`.split("\n")
-#   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-#   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-#   s.require_paths = ["lib"]
-
-#   s.add_runtime_dependency %q<niceogiri>, [">= 0.1.0"]
-#   s.add_runtime_dependency %q<activesupport>, [">= 3.0.7"]
-
-#   s.add_development_dependency %q<bundler>, ["~> 1.0.0"]
-#   s.add_development_dependency %q<rspec>, [">= 2.7.0"]
-#   s.add_development_dependency %q<ci_reporter>, [">= 1.6.3"]
-#   s.add_development_dependency %q<yard>, ["~> 0.7.0"]
-#   s.add_development_dependency %q<rake>, [">= 0"]
-#   s.add_development_dependency %q<mocha>, [">= 0"]
-#   s.add_development_dependency %q<i18n>, [">= 0"]
-# end

--- a/amp.gemspec
+++ b/amp.gemspec
@@ -2,10 +2,10 @@
 $:.push File.expand_path("../lib", __FILE__)
 #require "ruby_speech/version"
 
-Gem::Specification.new do # |s|
-  name        = "amp"
-  developer "Michael Edgar", "adgar@carboni.ca"
-  developer "Ari Brown", "seydar@carboni.ca"
+Gem::Specification.new do |s|
+  s.name        = "amp"
+  s.developer "Michael Edgar", "adgar@carboni.ca"
+  s.developer "Ari Brown", "seydar@carboni.ca"
   self.url = "http://amp.carboni.ca/"
   self.spec_extras = {:extensions => ["ext/amp/mercurial_patch/extconf.rb",
                                  "ext/amp/priority_queue/extconf.rb",

--- a/amp.gemspec
+++ b/amp.gemspec
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+#require "ruby_speech/version"
+
+Gem::Specification.new do # |s|
+  name        = "amp"
+  developer "Michael Edgar", "adgar@carboni.ca"
+  developer "Ari Brown", "seydar@carboni.ca"
+  self.url = "http://amp.carboni.ca/"
+  self.spec_extras = {:extensions => ["ext/amp/mercurial_patch/extconf.rb",
+                                 "ext/amp/priority_queue/extconf.rb",
+                                 "ext/amp/support/extconf.rb",
+                                 "ext/amp/bz2/extconf.rb"]}
+  self.need_rdoc = false
+  self.summary = "Version Control in Ruby. Mercurial Compatible. Big Ideas."
+  extra_dev_deps << ["rtfm", ">= 0.5.1"] << ["yard", ">= 0.4.0"] << ["minitest", ">= 1.5.0"]
+end
+
+# #  s.version     = RubySpeech::VERSION
+#   s.authors     = ["Ben Langfeld"]
+#   s.email       = ["ben@langfeld.me"]
+#   s.homepage    = "https://github.com/benlangfeld/ruby_speech"
+#   s.summary     = %q{A ruby library for TTS & ASR document preparation}
+#   s.description = %q{Prepare SSML and GRXML documents with ease}
+
+#   s.rubyforge_project = "ruby_speech"
+
+#   s.files         = `git ls-files`.split("\n")
+#   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+#   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+#   s.require_paths = ["lib"]
+
+#   s.add_runtime_dependency %q<niceogiri>, [">= 0.1.0"]
+#   s.add_runtime_dependency %q<activesupport>, [">= 3.0.7"]
+
+#   s.add_development_dependency %q<bundler>, ["~> 1.0.0"]
+#   s.add_development_dependency %q<rspec>, [">= 2.7.0"]
+#   s.add_development_dependency %q<ci_reporter>, [">= 1.6.3"]
+#   s.add_development_dependency %q<yard>, ["~> 0.7.0"]
+#   s.add_development_dependency %q<rake>, [">= 0"]
+#   s.add_development_dependency %q<mocha>, [">= 0"]
+#   s.add_development_dependency %q<i18n>, [">= 0"]
+# end

--- a/lib/amp/dependencies/zip/zip.rb
+++ b/lib/amp/dependencies/zip/zip.rb
@@ -3,7 +3,7 @@
 require 'delegate'
 require 'singleton'
 require 'tempfile'
-require 'ftools'
+require 'fileutils'
 require 'stringio'
 require 'zlib'
 

--- a/lib/amp/support/support.rb
+++ b/lib/amp/support/support.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##################################################################
 #                  Licensing Information                         #
 #                                                                #
@@ -14,7 +15,7 @@
 
 require 'digest'
 
-if RUBY_VERSION < "1.9" || RUBY_VERSION >= "1.9.2"
+if RUBY_VERSION < "1.9"
   require 'ftools'
   
   autoload :Etc,      'etc'


### PR DESCRIPTION
I wanted to use ruby 1.9 and reference amp via my Gemfile ie:

``` ruby
gem 'amp', :git => 'git@github.com:hh/amp.git', :branch => 'feature/ruby19-support'
```

These changes do that for me, and maybe for others.
